### PR TITLE
Deleted the pined versions for the documentation: openstack-configuration-reference

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-Jinja2==3.1.1
-PyYAML==6.0
-oslo.config==8.8.0
-Sphinx==4.5.0
+Jinja2
+PyYAML
+oslo.config
+Sphinx
 sphinx_toolbox
 sphinx_rtd_theme


### PR DESCRIPTION
- Remove the versions in the requirements.txt to fix upcoming version issues
- This is partly: osism/issues#180

Signed-off-by: Ramona Rautenberg <rautenberg@osism.tech>
